### PR TITLE
chore: add coverage to frontend .gitignore

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+coverage
 *.local
 
 # Editor directories and files


### PR DESCRIPTION
## Summary
- Adds `coverage/` to `frontend/.gitignore` so Vitest coverage output is not tracked by git

## Test plan
- [ ] Verify `frontend/coverage/` no longer appears in `git status` after running `npm test`